### PR TITLE
Fix implicit conversion changes signedness errors with clang 11

### DIFF
--- a/src/lib/firmware/fbsd.c
+++ b/src/lib/firmware/fbsd.c
@@ -671,7 +671,7 @@ cb_setreg(UNUSED void *arg, int r, uint64_t v)
 		abort();
 	}
 
-	error = xh_vm_set_register(BSP, vmreg, v);
+	error = xh_vm_set_register(BSP, (int)vmreg, v);
 	if (error) {
 		perror("xh_vm_set_register");
 		cb_exit();
@@ -698,7 +698,7 @@ cb_setmsr(UNUSED void *arg, u_int r, uint64_t v)
 		abort();
 	}
 
-	error = xh_vm_set_register(BSP, vmreg, v);
+	error = xh_vm_set_register(BSP, (int)vmreg, v);
 	if (error) {
 		perror("xh_vm_set_msr");
 		cb_exit();
@@ -733,7 +733,7 @@ cb_setcr(UNUSED void *arg, int r, uint64_t v)
 		cb_exit();
 	}
 
-	error = xh_vm_set_register(BSP, vmreg, v);
+	error = xh_vm_set_register(BSP, (int)vmreg, v);
 	if (error) {
 		perror("vm_set_cr");
 		cb_exit();

--- a/src/lib/inout.c
+++ b/src/lib/inout.c
@@ -102,7 +102,7 @@ update_register(int vcpuid, enum vm_reg_name reg,
 	switch (size) {
 	case 1:
 	case 2:
-		error = xh_vm_get_register(vcpuid, reg, &origval);
+		error = xh_vm_get_register(vcpuid, (int)reg, &origval);
 		if (error)
 			return (error);
 		val &= vie_size2mask(size);
@@ -117,7 +117,7 @@ update_register(int vcpuid, enum vm_reg_name reg,
 		return (EINVAL);
 	}
 
-	return xh_vm_set_register(vcpuid, reg, val);
+	return xh_vm_set_register(vcpuid, (int)reg, val);
 }
 
 int

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -1370,7 +1370,7 @@ static void handle_connect_fd(struct pci_vtsock_softc *sc, int accept_fd, uint64
 
 	DPRINTF(("TX: Connect attempt on connect fd => %d\n", fd));
 
-	if (cid == VMADDR_CID_ANY) {
+	if ((uint32_t)cid == VMADDR_CID_ANY) {
 		do {
 			bytes = read(fd, buf, sizeof(buf)-1);
 		} while (bytes == -1 && errno == EAGAIN);
@@ -1580,7 +1580,7 @@ static void *pci_vtsock_tx_thread(void *vsc)
 
 		if (FD_ISSET(sc->connect_fd, &rfd)) {
 			DPRINTF(("TX: Handling connect fd\n"));
-			handle_connect_fd(sc, sc->connect_fd, VMADDR_CID_ANY, 0);
+			handle_connect_fd(sc, sc->connect_fd, (uint32_t)VMADDR_CID_ANY, 0);
 		}
 
 		for (i = 0; i < sc->nr_fwds; i++) {
@@ -2292,7 +2292,7 @@ copy_up_to_comma(const char *from)
 static int
 pci_vtsock_init(struct pci_devinst *pi, char *opts)
 {
-	uint64_t guest_cid = VMADDR_CID_ANY;
+	uint32_t guest_cid = VMADDR_CID_ANY;
 	const char *path = NULL;
 	char *guest_forwards = NULL;
 	struct pci_vtsock_softc *sc;
@@ -2337,7 +2337,7 @@ pci_vtsock_init(struct pci_devinst *pi, char *opts)
 	}
 
 	if (guest_cid <= VMADDR_CID_HOST || guest_cid >= VMADDR_CID_MAX) {
-		fprintf(stderr, "invalid guest_cid "PRIcid"\n", guest_cid);
+		fprintf(stderr, "invalid guest_cid "PRIcid"\n", (uint64_t)guest_cid);
 		return 1;
 	}
 
@@ -2353,7 +2353,7 @@ pci_vtsock_init(struct pci_devinst *pi, char *opts)
 	/* XXX confirm path exists and is a directory */
 
 	fprintf(stderr, "vsock init %d:%d = %s, guest_cid = "PRIcid"\n\r",
-		pi->pi_slot, pi->pi_func, path, guest_cid);
+		pi->pi_slot, pi->pi_func, path, (uint64_t)guest_cid);
 
 	sc = calloc(1, sizeof(struct pci_vtsock_softc));
 

--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -1365,7 +1365,7 @@ inout_str_index(struct vmx *vmx, int vcpuid, int in)
 	enum vm_reg_name reg;
 
 	reg = in ? VM_REG_GUEST_RDI : VM_REG_GUEST_RSI;
-	error = vmx_getreg(vmx, vcpuid, reg, &val);
+	error = vmx_getreg(vmx, vcpuid, (int)reg, &val);
 	KASSERT(error == 0, ("%s: vmx_getreg error %d", __func__, error));
 	return (val);
 }
@@ -1416,7 +1416,7 @@ inout_str_seginfo(struct vmx *vmx, int vcpuid, uint32_t inst_info, int in,
 		vis->seg_name = vm_segment_name(s);
 	}
 
-	error = vmx_getdesc(vmx, vcpuid, vis->seg_name, &vis->seg_desc);
+	error = vmx_getdesc(vmx, vcpuid, (int)vis->seg_name, &vis->seg_desc);
 	KASSERT(error == 0, ("%s: vmx_getdesc error %d", __func__, error));
 }
 

--- a/src/lib/vmm/vmm_api.c
+++ b/src/lib/vmm/vmm_api.c
@@ -526,7 +526,7 @@ xh_vm_get_capability(int vcpu, enum vm_cap_type cap, int *retval)
 	int error;
 
 	vcpu_freeze(vcpu, true);
-	error = vm_get_capability(vm, vcpu, cap, retval);
+	error = vm_get_capability(vm, vcpu, (int)cap, retval);
 	vcpu_freeze(vcpu, false);
 
 	return (error);
@@ -538,7 +538,7 @@ xh_vm_set_capability(int vcpu, enum vm_cap_type cap, int val)
 	int error;
 
 	vcpu_freeze(vcpu, true);
-	error = vm_set_capability(vm, vcpu, cap, val);
+	error = vm_set_capability(vm, vcpu, (int)cap, val);
 	vcpu_freeze(vcpu, false);
 
 	return (error);

--- a/src/lib/vmm/vmm_instruction_emul.c
+++ b/src/lib/vmm/vmm_instruction_emul.c
@@ -244,7 +244,7 @@ vie_read_register(void *vm, int vcpuid, enum vm_reg_name reg, uint64_t *rval)
 {
 	int error;
 
-	error = vm_get_register(vm, vcpuid, reg, rval);
+	error = vm_get_register(vm, vcpuid, (int)reg, rval);
 
 	return (error);
 }
@@ -283,7 +283,7 @@ vie_read_bytereg(void *vm, int vcpuid, struct vie *vie, uint8_t *rval)
 	enum vm_reg_name reg;
 
 	vie_calc_bytereg(vie, &reg, &lhbr);
-	error = vm_get_register(vm, vcpuid, reg, &val);
+	error = vm_get_register(vm, vcpuid, (int)reg, &val);
 
 	/*
 	 * To obtain the value of a legacy high byte register shift the
@@ -304,7 +304,7 @@ vie_write_bytereg(void *vm, int vcpuid, struct vie *vie, uint8_t byte)
 	enum vm_reg_name reg;
 
 	vie_calc_bytereg(vie, &reg, &lhbr);
-	error = vm_get_register(vm, vcpuid, reg, &origval);
+	error = vm_get_register(vm, vcpuid, (int)reg, &origval);
 	if (error == 0) {
 		val = byte;
 		mask = 0xff;
@@ -317,7 +317,7 @@ vie_write_bytereg(void *vm, int vcpuid, struct vie *vie, uint8_t byte)
 			mask <<= 8;
 		}
 		val |= origval & ~mask;
-		error = vm_set_register(vm, vcpuid, reg, val);
+		error = vm_set_register(vm, vcpuid, (int)reg, val);
 	}
 	return (error);
 }
@@ -347,7 +347,7 @@ vie_update_register(void *vm, int vcpuid, enum vm_reg_name reg,
 		return (EINVAL);
 	}
 
-	error = vm_set_register(vm, vcpuid, reg, val);
+	error = vm_set_register(vm, vcpuid, (int)reg, val);
 	return (error);
 }
 
@@ -607,7 +607,7 @@ get_gla(void *vm, int vcpuid, UNUSED struct vie *vie,
 	error = vie_read_register(vm, vcpuid, VM_REG_GUEST_RFLAGS, &rflags);
 	KASSERT(error == 0, ("%s: error %d getting rflags", __func__, error));
 
-	error = vm_get_seg_desc(vm, vcpuid, seg, &desc);
+	error = vm_get_seg_desc(vm, vcpuid, (int)seg, &desc);
 	KASSERT(error == 0, ("%s: error %d getting segment descriptor %d",
 	    __func__, error, seg));
 
@@ -2063,7 +2063,7 @@ decode_modrm(struct vie *vie, enum vm_cpu_mode cpu_mode)
 	if (vie->mod != VIE_MOD_DIRECT && vie->rm == VIE_RM_SIB)
 		goto done;
 
-	vie->base_register = gpr_map[vie->rm];
+	vie->base_register = (int)gpr_map[vie->rm];
 
 	switch (vie->mod) {
 	case VIE_MOD_INDIRECT_DISP8:
@@ -2138,7 +2138,7 @@ decode_sib(struct vie *vie)
 		 */
 		vie->disp_bytes = 4;
 	} else {
-		vie->base_register = gpr_map[vie->base];
+		vie->base_register = (int)gpr_map[vie->base];
 	}
 
 	/*
@@ -2149,7 +2149,7 @@ decode_sib(struct vie *vie)
 	 * Table 2-5: Special Cases of REX Encodings
 	 */
 	if (vie->index != 4)
-		vie->index_register = gpr_map[vie->index];
+		vie->index_register = (int)gpr_map[vie->index];
 
 	/* 'scale' makes sense only in the context of an index register */
 	if (vie->index_register < VM_REG_LAST)


### PR DESCRIPTION
Signed-off-by: Jarrod Connolly <jarrod@nestedquotes.ca>